### PR TITLE
Added support for application/jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ server {
     
     location curity {
         proxy_pass "https://curity.example.com/oauth/v2/introspection";
-        proxy_set_header content-type "application/x-www-form-urlencoded";
     }
 }
 ```
@@ -145,7 +144,6 @@ server {
     
     location curity {
         proxy_pass "https://server2.example.com:8443/oauth/v2/introspection";
-        proxy_set_header content-type "application/x-www-form-urlencoded";
     }
 }
 
@@ -181,7 +179,6 @@ http {
         
         location curity {
             proxy_pass "https://server2.example.com:8443/oauth/v2/introspection";
-            proxy_set_header content-type "application/x-www-form-urlencoded";
             
             proxy_cache_methods POST;
             proxy_cache my_cache;

--- a/README.md
+++ b/README.md
@@ -210,8 +210,11 @@ make && make install
 
 This will download the NGINX source code if it is not already local. If it is, the location may be provided when prompted. By default, version 1.13.3 will be downloaded; a different version can be fetched by setting `NGINX_VERSION` before running the `configure` script. Any [additional parameters](http://nginx.org/en/docs/configure.html) (e.g., `--prefix`) that NGINX's `configure` script supports can also be provided. When this module's `configure` script is run, it will pass along `--add-module` and `--with-compat` to NGINX's script. It will also ask if debug flags should be enabled; if so, `--with-debug` and certain GCC flags will be passed on to NGINX's `configure` script to make debugging easier. After the script is run, just execute `make && make install`. These too will delegate to NGINX's `Makefile`. After this, the module will be usable and can be configured as described above.
 
-## Testing and Compatibility
+## Testing 
 TBD
+## Compatibility
+
+This module is compatible with Curity version > 2.2
 
 ## Status
  This module is still in development. Use it at your own risk!

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ This will download the NGINX source code if it is not already local. If it is, t
 TBD
 ## Compatibility
 
-This module is compatible with Curity version > 2.2
+This module is compatible with Curity version >= 2.2
 
 ## Status
  This module is still in development. Use it at your own risk!

--- a/nginx.conf
+++ b/nginx.conf
@@ -22,7 +22,6 @@ http {
 
         location curity {
             proxy_pass "http://localhost:8443/introspection-jwt";
-            proxy_set_header content-type "application/x-www-form-urlencoded";
 
             proxy_cache my_cache;
             proxy_cache_methods POST;

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,7 +23,6 @@ http {
         location curity {
             proxy_pass "http://localhost:8443/introspection-jwt";
             proxy_set_header content-type "application/x-www-form-urlencoded";
-            proxy_set_header accept "application/jwt";
 
             proxy_cache my_cache;
             proxy_cache_methods POST;

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,7 +14,7 @@ http {
  
         location / {
             proxy_pass         "http://httpbin.org/";
-            phantom_token_client_credential "client_id"; "client_secret";
+            phantom_token_client_credential "client_id" "client_secret";
             phantom_token_realm "api";
             phantom_token_scopes "a b c";
             phantom_token_introspection_endpoint curity;

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,6 +23,7 @@ http {
         location curity {
             proxy_pass "http://localhost:8443/introspection-jwt";
             proxy_set_header content-type "application/x-www-form-urlencoded";
+            proxy_set_header accept "application/jwt";
 
             proxy_cache my_cache;
             proxy_cache_methods POST;

--- a/phantom_token.c
+++ b/phantom_token.c
@@ -105,7 +105,6 @@ static ngx_int_t set_www_authenticate_header(ngx_http_request_t *request, ngx_st
  */
 static char* set_client_credential_configuration_slot(ngx_conf_t *config_setting, ngx_command_t *command, void *result);
 
-const static char JWT_KEY[] = "\"jwt\":\"";
 const static char BEARER[] = "Bearer ";
 const static size_t BEARER_SIZE = sizeof(BEARER) - 1;
 
@@ -520,7 +519,7 @@ static ngx_int_t introspection_response_handler(ngx_http_request_t *request, voi
 
     if (!request->cache || !request->cache->buf)
     {
-        jwt_start = request->header_end + 2; // +2 for padding \r\n
+        jwt_start = request->header_end + sizeof("\r\n") - 1;
     }
 
     if (jwt_start == NULL && request->cache && request->cache->buf && request->cache->valid_sec > 0)

--- a/phantom_token.c
+++ b/phantom_token.c
@@ -235,14 +235,10 @@ static ngx_int_t handler(ngx_http_request_t *request)
             {
                 return NGX_HTTP_SERVICE_UNAVAILABLE;
             }
-            else if (module_context->status >= NGX_HTTP_INTERNAL_SERVER_ERROR)
+            else if (module_context->status >= NGX_HTTP_INTERNAL_SERVER_ERROR || module_context->status == NGX_HTTP_NOT_FOUND
+                || module_context->status == NGX_HTTP_UNAUTHORIZED || module_context->status == NGX_HTTP_FORBIDDEN)
             {
                 return NGX_HTTP_BAD_GATEWAY;
-            }
-            else if (module_context->status == NGX_HTTP_UNAUTHORIZED ||
-                     module_context->status == NGX_HTTP_FORBIDDEN || module_context->status == NGX_HTTP_NOT_FOUND)
-            {
-                return NGX_HTTP_BAD_REQUEST;
             }
 
             return NGX_HTTP_INTERNAL_SERVER_ERROR;

--- a/phantom_token.c
+++ b/phantom_token.c
@@ -242,7 +242,7 @@ static ngx_int_t handler(ngx_http_request_t *request)
             else if (module_context->status == NGX_HTTP_NO_CONTENT)
             {
                 return set_www_authenticate_header(request, module_location_config->realm,
-                                                          module_location_config->space_separated_scopes, NULL);;
+                                                          module_location_config->space_separated_scopes, NULL);
             }
             else if (module_context->status == NGX_HTTP_SERVICE_UNAVAILABLE)
             {

--- a/phantom_token.c
+++ b/phantom_token.c
@@ -49,6 +49,7 @@ typedef struct
     ngx_uint_t done;
     ngx_uint_t status;
     ngx_str_t jwt;
+    ngx_str_t original_accept_header;
 } phantom_token_module_context_t;
 
 static ngx_int_t post_configuration(ngx_conf_t *config);
@@ -224,6 +225,8 @@ static ngx_int_t handler(ngx_http_request_t *request)
                 request->headers_in.authorization->value.len = module_context->jwt.len;
                 request->headers_in.authorization->value.data = module_context->jwt.data;
 
+                request->headers_in.accept->value = module_context->original_accept_header;
+
                 return NGX_OK;
             }
             else if (module_context->status == NGX_HTTP_NO_CONTENT)
@@ -365,6 +368,7 @@ static ngx_int_t handler(ngx_http_request_t *request)
     introspection_request->headers_in.content_length_n = ngx_buf_size(introspection_request_body_buffer);
 
 #if(NGX_HTTP_HEADERS)
+    module_context->original_accept_header = request->headers_in.accept->value;
     ngx_str_set(&introspection_request->headers_in.accept->value, "application/jwt");
 #endif
 

--- a/phantom_token.c
+++ b/phantom_token.c
@@ -351,6 +351,10 @@ static ngx_int_t handler(ngx_http_request_t *request)
     introspection_request->request_body = introspection_request_body;
     introspection_request->headers_in.content_length_n = ngx_buf_size(introspection_request_body_buffer);
 
+#if(NGX_HTTP_HEADERS)
+    ngx_str_set(&introspection_request->headers_in.accept->value, "application/jwt");
+#endif
+
     introspection_request->header_only = true;
 
     // Change subrequest method to POST

--- a/phantom_token.c
+++ b/phantom_token.c
@@ -228,7 +228,8 @@ static ngx_int_t handler(ngx_http_request_t *request)
             }
             else if (module_context->status == NGX_HTTP_NO_CONTENT)
             {
-                return NGX_HTTP_UNAUTHORIZED;
+                return set_www_authenticate_header(request, module_location_config->realm,
+                                                          module_location_config->space_separated_scopes, NULL);;
             }
             else if (module_context->status == NGX_HTTP_SERVICE_UNAVAILABLE)
             {


### PR DESCRIPTION
Fixes #6 #14 #19 
Caused #23 which was fixed in later commit in the same PR
Removed the parsing of the response body from Curity. Instead, when receiving a 200 OK from Curity, the body of the response will be the `jwt`. 

Should not be merged until Curity is ready to accept requests with `application/jwt`
