### PR TITLE
Do not fail to continue "clean" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build install modules upgrade: .build.info
 	cd $(NGINX_SRC_DIR) && $(MAKE) -e $@
 
 clean:
-	-cd $(NGINX_SRC_DIR) && $(MAKE) $@
+	test -d "$(NGINX_SRC_DIR)" && $(MAKE) -C $(NGINX_SRC_DIR) $@ || true
 	rm -rf .build.info nginx-$(NGINX_VERSION) nginx-$(NGINX_VERSION).tar.gz*
 
 .build.info:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build install modules upgrade: .build.info
 	cd $(NGINX_SRC_DIR) && $(MAKE) -e $@
 
 clean:
-	cd $(NGINX_SRC_DIR) && $(MAKE) $@
+	-cd $(NGINX_SRC_DIR) && $(MAKE) $@
 	rm -rf .build.info nginx-$(NGINX_VERSION) nginx-$(NGINX_VERSION).tar.gz*
 
 .build.info:


### PR DESCRIPTION
  When user manually rm local "nginx" source folder, by running "make clean" should still do the cleanup for local repo