### PR TITLE
Added JSON error responses

### DIFF
--- a/phantom_token.c
+++ b/phantom_token.c
@@ -870,7 +870,7 @@ static ngx_int_t write_error_response(ngx_http_request_t *request, ngx_int_t sta
         output.buf = body;
         output.next = NULL;
 
-        /* When setting a body ourself we must return the result of the filter, to prevent a 'header already sent' error */
+        /* When setting a body ourself we must return the result of the filter */
         return ngx_http_output_filter(request, &output);
     }
 }

--- a/phantom_token.c
+++ b/phantom_token.c
@@ -821,8 +821,8 @@ static ngx_int_t write_error_response(ngx_http_request_t *request, ngx_int_t sta
     u_char json_error_data[256];
     ngx_chain_t output;
     ngx_buf_t *body = NULL;
-    const char *errorFormat = NULL;
-    size_t errorLen = 0;
+    const char *error_format = NULL;
+    size_t error_len = 0;
 
     if (request->method == NGX_HTTP_HEAD)
     {
@@ -849,13 +849,13 @@ static ngx_int_t write_error_response(ngx_http_request_t *request, ngx_int_t sta
         }
 
         /* The string length calculation replaces the two '%V' markers with their actual values */
-        errorFormat = "{\"code\":\"%V\",\"message\":\"%V\"}";
-        errorLen = ngx_strlen(errorFormat) + code.len + message.len - 4;
-        ngx_snprintf(json_error_data, sizeof(json_error_data) - 1, errorFormat, &code, &message);
-        json_error_data[errorLen] = 0;
+        error_format = "{\"code\":\"%V\",\"message\":\"%V\"}";
+        error_len = ngx_strlen(error_format) + code.len + message.len - 4;
+        ngx_snprintf(json_error_data, sizeof(json_error_data) - 1, error_format, &code, &message);
+        json_error_data[error_len] = 0;
 
         request->headers_out.status = status;
-        request->headers_out.content_length_n = errorLen;
+        request->headers_out.content_length_n = error_len;
         ngx_str_set(&request->headers_out.content_type, "application/json");
         rc = ngx_http_send_header(request);
         if (rc == NGX_ERROR || rc > NGX_OK || request->header_only) {
@@ -863,14 +863,15 @@ static ngx_int_t write_error_response(ngx_http_request_t *request, ngx_int_t sta
         }
         
         body->pos = json_error_data;
-        body->last = json_error_data + errorLen;
+        body->last = json_error_data + error_len;
         body->memory = 1;
         body->last_buf = 1;
         body->last_in_chain = 1;
         output.buf = body;
         output.next = NULL;
 
-        /* When setting a body ourself we must return the result of the filter */
-        return ngx_http_output_filter(request, &output);
+        /* Return an error result to prevent a 'header already sent' warning in logs */
+        ngx_http_output_filter(request, &output);
+        return NGX_ERROR;
     }
 }

--- a/resources/memorytest/run.sh
+++ b/resources/memorytest/run.sh
@@ -5,7 +5,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 #
 # Input parameters
 #
-LICENSE_FILE_PATH=
 ADMIN_PASSWORD=Password1
 
 #

--- a/resources/test/run.sh
+++ b/resources/test/run.sh
@@ -5,7 +5,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 #
 # Input parameters
 #
-LICENSE_FILE_PATH=
 ADMIN_PASSWORD=Password1
 
 #

--- a/t/curity.t
+++ b/t/curity.t
@@ -105,7 +105,7 @@ content-type: application/json
 WWW-Authenticate: Bearer realm="api"
 
 --- response_body_like chomp
-{"code":"unauthorized_request", "message":"Access denied due to missing, invalid or expired credentials"}
+{"code":"unauthorized_request","message":"Access denied due to missing, invalid or expired credentials"}
 
 
 === Test 3: The wrong kind of HTTP method is used results in an access denied error
@@ -156,7 +156,7 @@ content-type: application/json
 WWW-Authenticate: Bearer realm="api"
 
 --- response_body_like chomp
-{"code":"unauthorized_request", "message":"Access denied due to missing, invalid or expired credentials"}
+{"code":"unauthorized_request","message":"Access denied due to missing, invalid or expired credentials"}
 
 === Test 4: A valid token with trash after results in an access denied error
 

--- a/t/curity.t
+++ b/t/curity.t
@@ -107,7 +107,6 @@ WWW-Authenticate: Bearer realm="api"
 --- response_body_like chomp
 {"code":"unauthorized_request","message":"Access denied due to missing, invalid or expired credentials"}
 
-
 === Test 3: The wrong kind of HTTP method is used results in an access denied error
 
 --- config
@@ -158,7 +157,7 @@ WWW-Authenticate: Bearer realm="api"
 --- response_body_like chomp
 {"code":"unauthorized_request","message":"Access denied due to missing, invalid or expired credentials"}
 
-=== Test 4: A valid token with trash after results in an access denied error
+=== Test 5: A valid token with trash after results in an access denied error
 
 --- config
 location tt {
@@ -185,7 +184,7 @@ GET /t
 content-type: application/json
 WWW-Authenticate: Bearer realm="api"
 
-=== Test 5: The bearer HTTP method can be in upper case
+=== Test 6: The bearer HTTP method can be in upper case
 
 --- config
 location tt {
@@ -213,7 +212,7 @@ main::process_json_from_backend()
 
 --- response_body: GOOD
 
-=== Test 6: The bearer HTTP method can be in mixed case
+=== Test 7: The bearer HTTP method can be in mixed case
 
 --- config
 location tt {
@@ -241,7 +240,7 @@ main::process_json_from_backend()
 
 --- response_body: GOOD
 
-=== Test 6: The bearer HTTP method can have > 1 space before it
+=== Test 8: The bearer HTTP method can have > 1 space before it
 
 --- config
 location tt {
@@ -268,3 +267,61 @@ GET /t
 main::process_json_from_backend()
 
 --- response_body: GOOD
+
+=== Test 9: A misconfigured client secret results in a 502 error
+
+--- config
+location tt {
+    proxy_pass "http://localhost:8443/oauth/v2/oauth-introspect";
+}
+
+location /t {
+    proxy_pass         "http://localhost:8080/anything";
+
+    phantom_token on;
+    phantom_token_client_credential "test-nginx" "incorrect_secret";
+    phantom_token_introspection_endpoint tt;
+}
+
+--- error_code: 502
+
+--- request
+GET /t
+
+--- more_headers eval
+"Authorization: bearer               " . $main::token
+
+--- response_headers
+content-type: application/json
+
+--- response_body_like chomp
+{"code":"server_error","message":"Problem encountered processing the request"}
+
+=== Test 10: An unreachable authorization server results in a 502 error
+
+--- config
+location tt {
+    proxy_pass "http://localhost:9443/oauth/v2/oauth-introspect";
+}
+
+location /t {
+    proxy_pass         "http://localhost:8080/anything";
+
+    phantom_token on;
+    phantom_token_client_credential "test-nginx" "secret2";
+    phantom_token_introspection_endpoint tt;
+}
+
+--- error_code: 502
+
+--- request
+GET /t
+
+--- more_headers eval
+"Authorization: bearer               " . $main::token
+
+--- response_headers
+content-type: application/json
+
+--- response_body_like chomp
+{"code":"server_error","message":"Problem encountered processing the request"}

--- a/t/curity.t
+++ b/t/curity.t
@@ -100,6 +100,14 @@ GET /t
 
 --- error_code: 401
 
+--- response_headers
+content-type: application/json
+WWW-Authenticate: Bearer realm="api"
+
+--- response_body_like chomp
+{"code":"unauthorized_request", "message":"Access denied due to missing, invalid or expired credentials"}
+
+
 === Test 3: The wrong kind of HTTP method is used results in an access denied error
 
 --- config
@@ -143,6 +151,13 @@ GET /t
 
 --- error_code: 401
 
+--- response_headers
+content-type: application/json
+WWW-Authenticate: Bearer realm="api"
+
+--- response_body_like chomp
+{"code":"unauthorized_request", "message":"Access denied due to missing, invalid or expired credentials"}
+
 === Test 4: A valid token with trash after results in an access denied error
 
 --- config
@@ -165,6 +180,10 @@ GET /t
 "Authorization: bearer " . $main::token . "z"
 
 --- error_code: 401
+
+--- response_headers
+content-type: application/json
+WWW-Authenticate: Bearer realm="api"
 
 === Test 5: The bearer HTTP method can be in upper case
 


### PR DESCRIPTION
During SPA testing we noticed that no error payload was returned by the plugin, and NGINX generated its own default payload. This might be a little tricky to handle in web and mobile clients when access tokens expire:

```text
Status 401
WWW-Authenticate: Bearer realm="api"
Content-Type: text/html
```

```html
<html>
<head><title>401 Authorization Required</title></head>
<body>
<center><h1>401 Authorization Required</h1></center>
<hr><center>nginx/1.21.3</center>
</body>
</html>
```

I discussed this with Travis a while back and we said we'd update it to JSON responses of this form:

```text
Status 401
WWW-Authenticate: Bearer realm="api"
Content-Type: application/json
```

```json
{"code":"unauthorized_request", "message":"Access denied due to missing, invalid or expired credentials"}
```

I have added a `write_error_response` routine and called it for all main error occurrences. When a memory allocation has occurred I do not call this routine, since the assumption is that this would just fail memory allocation again and lose the original error.

I also added a couple of tests also for these scenarios, since I think they are useful test cases:

- Incorrect introspection client secret configured
- Incorrect introspection URL configured, or server unreachable